### PR TITLE
[webhook] support cbor as metadata format

### DIFF
--- a/webhook/attribute.go
+++ b/webhook/attribute.go
@@ -4,13 +4,13 @@ import (
 	"github.com/starlinglab/integrity-v2/aa"
 )
 
-// ParseJsonToAttributes parses a JSON map and a file stat map
+// ParseMapToAttributes parses a map and a file stat map
 // to a slice of attributes for POSTing to the AA server
-func ParseJsonToAttributes(jsonMap map[string]any, fileAttributes map[string]any) []aa.PostKV {
+func ParseMapToAttributes(attrMap map[string]any, fileAttributes map[string]any) []aa.PostKV {
 
 	var attributes []aa.PostKV
 
-	for k, v := range jsonMap {
+	for k, v := range attrMap {
 		// TODO: add whitelist/blacklist for attributes in config
 		if k != "private" {
 			attributes = append(attributes, aa.PostKV{Key: k, Value: v})

--- a/webhook/client.go
+++ b/webhook/client.go
@@ -7,10 +7,13 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	urlpkg "net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
+	"github.com/fxamacker/cbor/v2"
 	"github.com/starlinglab/integrity-v2/config"
 )
 
@@ -20,11 +23,22 @@ var client = &http.Client{}
 type PostGenericWebhookOpt struct {
 	Source    string // Source is the origin of the asset, which is used to determine the webhook endpoint
 	ProjectId string // ProjectId is the project specific ID where the asset belongs
+	Format    string // Format is "json" or "cbor"
 }
 
 type PostGenericWebhookResponse struct {
 	Cid   string `json:"cid,omitempty"`
 	Error error  `json:"error,omitempty"`
+}
+
+// createFormFieldWithContentType is a modified multipart.Writer.CreateFormField
+// which allow setting of content-type
+func createFormFieldWithContentType(w *multipart.Writer, fieldName string, contentType string) (io.Writer, error) {
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition",
+		fmt.Sprintf(`form-data; name="%s"`, strings.NewReplacer("\\", "\\\\", `"`, "\\\"").Replace(fieldName)))
+	h.Set("Content-Type", contentType)
+	return w.CreatePart(h)
 }
 
 // PostFileToWebHook posts a file and its metadata to the webhook server
@@ -44,13 +58,23 @@ func PostFileToWebHook(filePath string, metadata map[string]any, opts PostGeneri
 	pr, pw := io.Pipe()
 	mp := multipart.NewWriter(pw)
 
+	metadataFormatType := "application/json"
+	if opts.Format == "cbor" {
+		metadataFormatType = "application/cbor"
+	}
+
 	go func() {
-		metadataString, err := json.Marshal(metadata)
+		metadataPart, err := createFormFieldWithContentType(mp, "metadata", metadataFormatType)
 		if err != nil {
 			pw.CloseWithError(err)
 			return
 		}
-		err = mp.WriteField("metadata", string(metadataString))
+		if metadataFormatType == "application/cbor" {
+			err = cbor.NewEncoder(metadataPart).Encode(metadata)
+
+		} else {
+			err = json.NewEncoder(metadataPart).Encode(metadata)
+		}
 		if err != nil {
 			pw.CloseWithError(err)
 			return
@@ -61,12 +85,12 @@ func PostFileToWebHook(filePath string, metadata map[string]any, opts PostGeneri
 			return
 		}
 		defer file.Close()
-		part, err := mp.CreateFormFile("file", filepath.Base(filePath))
+		filePart, err := mp.CreateFormFile("file", filepath.Base(filePath))
 		if err != nil {
 			pw.CloseWithError(err)
 			return
 		}
-		_, err = io.Copy(part, file)
+		_, err = io.Copy(filePart, file)
 		if err != nil {
 			pw.CloseWithError(err)
 			return


### PR DESCRIPTION
Base on https://github.com/starlinglab/integrity-v2/pull/6
Require for https://github.com/starlinglab/integrity-v2/pull/18 which I would rebase later
Set and check for `content-type` header in `metadata` field of a webhook multipart form