### PR TITLE
Couple of Proofmode-related fixes

### DIFF
--- a/preprocessor/proofmode/proofmode.go
+++ b/preprocessor/proofmode/proofmode.go
@@ -111,7 +111,15 @@ func validateAndParseFileSignatures(
 	// read asset
 	assetFile, err := openFile(fileMap, fileName)
 	if err != nil {
-		return nil, err
+		// Filename in metadata may differ from the ZIP (e.g. iOS Photos renames
+		// timestamp-named files to IMG_XXXX.JPG). Fall back to the content-hash
+		// key added by parseBundleAssetInfo.
+		origErr := err
+		fileName = fileSha
+		assetFile, err = openFile(fileMap, fileName)
+		if err != nil {
+			return nil, origErr
+		}
 	}
 	headerBytes := make([]byte, 512)
 	_, err = io.ReadFull(assetFile, headerBytes)
@@ -264,6 +272,12 @@ func parseBundleAssetInfo(zipReader *zip.ReadCloser) (map[string]*zip.File, [][]
 			jsonFilesBytes = append(jsonFilesBytes, jsonFileBytes)
 		} else {
 			fileMap[file.Name] = file
+			if rc, err := file.Open(); err == nil {
+				h := sha256.New()
+				io.Copy(h, rc)
+				rc.Close()
+				fileMap[hex.EncodeToString(h.Sum(nil))] = file
+			}
 		}
 	}
 	return fileMap, jsonFilesBytes, nil

--- a/preprocessor/proofmode/proofmode.go
+++ b/preprocessor/proofmode/proofmode.go
@@ -192,14 +192,17 @@ func validateAndParseFileSignatures(
 		return nil, fmt.Errorf("metadata signature verification failed")
 	}
 
-	otsFile, err := openFile(fileMap, fileSha+".ots")
-	if err != nil {
-		return nil, err
-	}
-	defer otsFile.Close()
-	otsBytes, err := io.ReadAll(otsFile)
-	if err != nil {
-		return nil, err
+	var otsBytes []byte
+	if _, ok := fileMap[fileSha+".ots"]; ok {
+		otsFile, err := openFile(fileMap, fileSha+".ots")
+		if err != nil {
+			return nil, err
+		}
+		defer otsFile.Close()
+		otsBytes, err = io.ReadAll(otsFile)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// On Android there is a .gst file (Google SafetyNet)


### PR DESCRIPTION
The issue are some Proofmode bundles we received in the RS project.

Problem 1: It looks like some images were exported from iOS Photos (which renames to IMG_XXXX) instead of being shared directly from Proofmode. Proof CSV expects `1767736865948.jpg`, but sees `IMG_3548.JPG`. On ingest, it errors with "Missing file".

Second problem: some photos are missing their `.ots` notarization files. They're otherwise GPG-signed and device-attested, so not sure what's going on.

---

Two fixes for bundles exported via iOS Photos, where filenames differ from what proof metadata records:
 
- Filename mismatch: when the exact filename from FilePath metadata isn't in the ZIP, fall back to matching by content hash. Files are now double-indexed in parseBundleAssetInfo by both name and SHA-256.
 
- Missing .ots: make OpenTimestamps files optional, consistent with .gst and .devicecheck.

