### PR TITLE
Add `starling file pfp <cid>` command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,6 +18,7 @@ Depending on how the binary is built, each CLI tool can either be called by runn
   - `encrypt`: encrypt a file already stored in the system
   - `cid`: calculate a CIDv1 for a file
   - `c2pa`: inject a file with AA metadata using C2PA
+  - `pfp`: compute a Nectar perceptual fingerprint for a stored file and record it as the `pfp` attribute (for backfilling if Nectar was unavailable at ingest time)
   - `register`: register a file with a third-party blockchain
   - `upload`: upload a file to a third-party storage provider
 - `genkey`: create a cryptographic key for use with Authenticated Attributes

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/starlinglab/integrity-v2/export"
 	"github.com/starlinglab/integrity-v2/genkey"
 	"github.com/starlinglab/integrity-v2/get"
+	"github.com/starlinglab/integrity-v2/pfp"
 	preprocessorfolder "github.com/starlinglab/integrity-v2/preprocessor/folder"
 	"github.com/starlinglab/integrity-v2/register"
 	"github.com/starlinglab/integrity-v2/relate"
@@ -41,6 +42,7 @@ Commands to run on the server:
     starling file register
     starling file cid
     starling file c2pa
+    starling file pfp
 
 Further documentation on CLI tools is listed online:
 https://github.com/starlinglab/integrity-v2/blob/main/docs/cli.md
@@ -99,6 +101,8 @@ func run(group string, args []string) (bool, error) {
 			err = cid.Run(args)
 		case "c2pa":
 			err = c2pa.Run(args)
+		case "pfp":
+			err = pfp.Run(args)
 		default:
 			// Unknown command
 			return false, nil

--- a/pfp/cmd/main.go
+++ b/pfp/cmd/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"os"
+
+	"github.com/starlinglab/integrity-v2/pfp"
+	"github.com/starlinglab/integrity-v2/util"
+)
+
+func main() {
+	util.Runner(os.Args[1:], pfp.Run)
+}

--- a/pfp/pfp.go
+++ b/pfp/pfp.go
@@ -1,0 +1,91 @@
+package pfp
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/starlinglab/integrity-v2/aa"
+	"github.com/starlinglab/integrity-v2/config"
+	"github.com/starlinglab/integrity-v2/nectar"
+	"github.com/starlinglab/integrity-v2/util"
+)
+
+// aaClient is the subset of *aa.AuthAttrInstance that computeAndSetPFP needs. It exists so
+// tests can substitute an in-memory fake instead of going through config/network, the same way
+// computeImagePFP (webhook/file.go) takes its config explicitly rather than reading globals.
+type aaClient interface {
+	GetAttestation(cid, attr string, opts aa.GetAttOpts) (*aa.AttEntry, error)
+	SetAttestations(cid string, index bool, kvs []aa.PostKV) error
+}
+
+func Run(args []string) error {
+	fs := flag.NewFlagSet("pfp", flag.ContinueOnError)
+	force := fs.Bool("force", false, "recompute and overwrite an existing pfp attribute")
+
+	err := fs.Parse(args)
+	if err != nil {
+		os.Exit(1)
+	}
+	if fs.NArg() != 1 {
+		return fmt.Errorf("provide a single CID to work with")
+	}
+	cid := fs.Arg(0)
+
+	pfpVal, err := computeAndSetPFP(
+		context.Background(), config.GetConfig(), aa.GetAAInstanceFromConfig(), cid, *force)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(pfpVal)
+	return nil
+}
+
+// computeAndSetPFP backfills the pfp attribute for cid, returning its value (existing or freshly
+// computed). Unless force is true, an existing pfp attribute short-circuits the whole operation
+// (no Nectar call, no AA write) and its value is returned as-is: this command's purpose is
+// filling in *missing* values, so an existing one is the expected steady state, not an error to
+// route around.
+func computeAndSetPFP(ctx context.Context, conf *config.Config, aaInst aaClient, cid string, force bool) (string, error) {
+	if conf.Nectar.Url == "" {
+		return "", fmt.Errorf("nectar is not configured, set [nectar] url in the config file")
+	}
+
+	if !force {
+		ae, err := aaInst.GetAttestation(cid, "pfp", aa.GetAttOpts{})
+		if err != nil && !errors.Is(err, aa.ErrNotFound) {
+			return "", fmt.Errorf("checking for existing pfp attestation: %w", err)
+		}
+		if err == nil {
+			return fmt.Sprint(ae.Attestation.Value), nil
+		}
+	}
+
+	cidPath := filepath.Join(conf.Dirs.Files, cid)
+	if _, err := os.Stat(cidPath); err != nil {
+		return "", fmt.Errorf("file not found for CID %s: %w", cid, err)
+	}
+
+	mediaType, err := util.GuessMediaType(cidPath)
+	if err != nil {
+		return "", fmt.Errorf("guessing media type: %w", err)
+	}
+	if !nectar.SupportsMediaType(mediaType) {
+		return "", fmt.Errorf("media type %s is not supported for pfp generation", mediaType)
+	}
+
+	pfpVal, err := nectar.ComputePFP(ctx, conf.Nectar.Url, conf.Nectar.Token, cidPath)
+	if err != nil {
+		return "", fmt.Errorf("computing pfp: %w", err)
+	}
+
+	if err := aaInst.SetAttestations(cid, true, []aa.PostKV{{Key: "pfp", Value: pfpVal, Type: "str"}}); err != nil {
+		return "", fmt.Errorf("setting pfp attestation: %w", err)
+	}
+
+	return pfpVal, nil
+}

--- a/pfp/pfp_integration_test.go
+++ b/pfp/pfp_integration_test.go
@@ -1,0 +1,79 @@
+package pfp
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/starlinglab/integrity-v2/aa"
+	"github.com/starlinglab/integrity-v2/config"
+)
+
+// nectarLiveOrSkip returns the live Nectar endpoint URL and access token from the environment,
+// skipping the test unless both are set. Mirrors nectar/nectar_integration_test.go's
+// nectarLiveOrSkip, so plain `go test ./...` stays offline.
+func nectarLiveOrSkip(t *testing.T) (url, token string) {
+	t.Helper()
+	url = os.Getenv("NECTAR_URL")
+	token = os.Getenv("NECTAR_TOKEN")
+	if url == "" || token == "" {
+		t.Skip("set NECTAR_URL and NECTAR_TOKEN to run the live Nectar integration test")
+	}
+	return url, token
+}
+
+// genPatternedPNG returns the bytes of a small non-uniform PNG, matching
+// nectar/nectar_integration_test.go's fixture: a patterned image gives the live service
+// something real to fingerprint, unlike a flat single-color one.
+func genPatternedPNG(t *testing.T) []byte {
+	t.Helper()
+	const size = 64
+	img := image.NewRGBA(image.Rect(0, 0, size, size))
+	for y := range size {
+		for x := range size {
+			v := uint8(x ^ y)
+			img.Set(x, y, color.RGBA{R: v, G: v, B: v, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encoding test png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// TestLivePFPBackfill runs computeAndSetPFP against the real Nectar /pfps endpoint, exercising
+// the full CLI code path (file lookup by CID, media-type gating, the Nectar call itself) rather
+// than nectar.computePFPFromReader in isolation as nectar/nectar_integration_test.go does.
+//
+// AA is stubbed with Mock: true so this test depends on nothing but a live Nectar, and force is
+// set so the (already unit-tested) existing-value guard is bypassed rather than needing a real
+// AA to check against. Run it with:
+//
+//	NECTAR_URL=https://<host> NECTAR_TOKEN=<token> go test -v -run LivePFPBackfill ./pfp/
+func TestLivePFPBackfill(t *testing.T) {
+	url, token := nectarLiveOrSkip(t)
+
+	dir := t.TempDir()
+	const cid = "integration-test-cid"
+	writeCidFile(t, dir, cid, genPatternedPNG(t))
+
+	conf := &config.Config{}
+	conf.Nectar.Url = url
+	conf.Nectar.Token = token
+	conf.Dirs.Files = dir
+
+	pfp, err := computeAndSetPFP(context.Background(), conf, &aa.AuthAttrInstance{Mock: true}, cid, true)
+	if err != nil {
+		t.Fatalf("live pfp backfill failed: %v", err)
+	}
+	if !strings.HasPrefix(pfp, "p") {
+		t.Errorf("pfp = %q, want a DASL \"p...\" string", pfp)
+	}
+	t.Logf("live pfp: %s", pfp)
+}

--- a/pfp/pfp_test.go
+++ b/pfp/pfp_test.go
@@ -1,0 +1,228 @@
+package pfp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"image"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/starlinglab/integrity-v2/aa"
+	"github.com/starlinglab/integrity-v2/config"
+)
+
+// fakeAA is an in-memory stand-in for *aa.AuthAttrInstance. This drives computeAndSetPFP's
+// guard logic directly.
+type fakeAA struct {
+	existing *aa.AttEntry // nil means "not found"
+	getErr   error        // takes priority over existing, for non-ErrNotFound failures
+	setErr   error
+
+	getCalls int
+	setCalls []aa.PostKV
+}
+
+func (f *fakeAA) GetAttestation(cid, attr string, opts aa.GetAttOpts) (*aa.AttEntry, error) {
+	f.getCalls++
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if f.existing == nil {
+		return nil, aa.ErrNotFound
+	}
+	return f.existing, nil
+}
+
+func (f *fakeAA) SetAttestations(cid string, index bool, kvs []aa.PostKV) error {
+	f.setCalls = append(f.setCalls, kvs...)
+	return f.setErr
+}
+
+func attEntryWithValue(v string) *aa.AttEntry {
+	ae := &aa.AttEntry{}
+	ae.Attestation.Value = v
+	return ae
+}
+
+// writeCidFile writes b to dir/cid (files are stored flat, keyed by CID with no extension) and
+// returns cid, mirroring how upload/upload.go and c2pa/c2pa.go lay files out on disk.
+func writeCidFile(t *testing.T, dir, cid string, b []byte) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, cid), b, 0600); err != nil {
+		t.Fatalf("writing cid file: %v", err)
+	}
+}
+
+func pngBytes(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, image.NewRGBA(image.Rect(0, 0, 1, 1))); err != nil {
+		t.Fatalf("encoding png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// pfpServer returns an httptest.Server that answers Nectar /pfps with a well-formed PFP,
+// counting how many times it was hit.
+func pfpServer(t *testing.T, pfp string) (srv *httptest.Server, calls *int) {
+	t.Helper()
+	calls = new(int)
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"blobs":[{"pfp":"` + pfp + `"}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, calls
+}
+
+func testConf(filesDir, nectarURL string) *config.Config {
+	conf := &config.Config{}
+	conf.Nectar.Url = nectarURL
+	conf.Dirs.Files = filesDir
+	return conf
+}
+
+func TestComputeAndSetPFP(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("nectar not configured", func(t *testing.T) {
+		fa := &fakeAA{}
+		_, err := computeAndSetPFP(ctx, testConf(t.TempDir(), ""), fa, "somecid", false)
+		if err == nil {
+			t.Fatal("expected an error when nectar is not configured")
+		}
+		if fa.getCalls != 0 || fa.setCalls != nil {
+			t.Errorf("no AA calls should happen before the nectar check: get=%d, set=%v", fa.getCalls, fa.setCalls)
+		}
+	})
+
+	t.Run("existing value short-circuits", func(t *testing.T) {
+		srv, calls := pfpServer(t, "pfresh")
+		fa := &fakeAA{existing: attEntryWithValue("pexisting")}
+
+		dir := t.TempDir()
+		got, err := computeAndSetPFP(ctx, testConf(dir, srv.URL), fa, "somecid", false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "pexisting" {
+			t.Errorf("got %q, want existing value %q", got, "pexisting")
+		}
+		if *calls != 0 {
+			t.Errorf("nectar should not be called when a pfp already exists, got %d calls", *calls)
+		}
+		if fa.setCalls != nil {
+			t.Errorf("AA should not be written to when a pfp already exists, got %v", fa.setCalls)
+		}
+	})
+
+	t.Run("force recomputes and overwrites existing value", func(t *testing.T) {
+		srv, calls := pfpServer(t, "pfresh")
+		fa := &fakeAA{existing: attEntryWithValue("pexisting")}
+
+		dir := t.TempDir()
+		writeCidFile(t, dir, "somecid", pngBytes(t))
+
+		got, err := computeAndSetPFP(ctx, testConf(dir, srv.URL), fa, "somecid", true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "pfresh" {
+			t.Errorf("got %q, want freshly computed value %q", got, "pfresh")
+		}
+		if *calls != 1 {
+			t.Errorf("nectar should be called exactly once with force, got %d calls", *calls)
+		}
+		if fa.getCalls != 0 {
+			t.Errorf("the existing-value check should be skipped entirely with force, got %d get calls", fa.getCalls)
+		}
+		if len(fa.setCalls) != 1 || fa.setCalls[0].Value != "pfresh" {
+			t.Errorf("expected a single set of the fresh value, got %v", fa.setCalls)
+		}
+	})
+
+	t.Run("no existing value computes and sets", func(t *testing.T) {
+		srv, calls := pfpServer(t, "pnew")
+		fa := &fakeAA{}
+
+		dir := t.TempDir()
+		writeCidFile(t, dir, "somecid", pngBytes(t))
+
+		got, err := computeAndSetPFP(ctx, testConf(dir, srv.URL), fa, "somecid", false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "pnew" {
+			t.Errorf("got %q, want %q", got, "pnew")
+		}
+		if *calls != 1 {
+			t.Errorf("expected exactly one nectar call, got %d", *calls)
+		}
+		if len(fa.setCalls) != 1 || fa.setCalls[0].Key != "pfp" || fa.setCalls[0].Value != "pnew" || fa.setCalls[0].Type != "str" {
+			t.Errorf("unexpected attestation written: %+v", fa.setCalls)
+		}
+	})
+
+	t.Run("aa get error other than not-found propagates", func(t *testing.T) {
+		srv, calls := pfpServer(t, "pfresh")
+		fa := &fakeAA{getErr: errors.New("aa unreachable")}
+
+		_, err := computeAndSetPFP(ctx, testConf(t.TempDir(), srv.URL), fa, "somecid", false)
+		if err == nil {
+			t.Fatal("expected error to propagate")
+		}
+		if *calls != 0 {
+			t.Errorf("nectar should not be called when the existence check fails, got %d calls", *calls)
+		}
+	})
+
+	t.Run("missing file on disk", func(t *testing.T) {
+		srv, _ := pfpServer(t, "pfresh")
+		fa := &fakeAA{}
+		_, err := computeAndSetPFP(ctx, testConf(t.TempDir(), srv.URL), fa, "nonexistent", false)
+		if err == nil {
+			t.Fatal("expected an error for a CID with no file on disk")
+		}
+	})
+
+	t.Run("unsupported media type", func(t *testing.T) {
+		srv, calls := pfpServer(t, "pfresh")
+		fa := &fakeAA{}
+
+		dir := t.TempDir()
+		writeCidFile(t, dir, "somecid", []byte("just some text, not an image\n"))
+
+		_, err := computeAndSetPFP(ctx, testConf(dir, srv.URL), fa, "somecid", false)
+		if err == nil {
+			t.Fatal("expected an error for an unsupported media type")
+		}
+		if *calls != 0 {
+			t.Errorf("nectar should not be called for an unsupported media type, got %d calls", *calls)
+		}
+		if fa.setCalls != nil {
+			t.Errorf("AA should not be written to for an unsupported media type, got %v", fa.setCalls)
+		}
+	})
+
+	t.Run("aa set error propagates", func(t *testing.T) {
+		srv, calls := pfpServer(t, "pfresh")
+		fa := &fakeAA{setErr: errors.New("aa write failed")}
+
+		dir := t.TempDir()
+		writeCidFile(t, dir, "somecid", pngBytes(t))
+
+		_, err := computeAndSetPFP(ctx, testConf(dir, srv.URL), fa, "somecid", false)
+		if err == nil {
+			t.Fatal("expected the AA write error to propagate")
+		}
+		if *calls != 1 {
+			t.Errorf("nectar should still have been called once before the failed write, got %d", *calls)
+		}
+	})
+}


### PR DESCRIPTION
### Summary

PFP computation only happens once during ingest. If Nectar was not configured at ingest time, the file's AA record ends up with no `pfp` attribute with no recovery path. This PR adds a CLI command compute the PFP and write it to AA (the same outcome as if Nectar had been available at ingest).

### Changes

* `pfp/pfp.go`: new `pfp` package. The core logic lives in `computeAndSetPFP`, which takes explicit `conf` and `aaClient` dependencies (following the `computeImagePFP(ctx, conf, path)` pattern from webhook/file.go) for testability. By default, it checks AA for an existing `pfp` attribute first and exits 0 printing the existing value if found. This skips the Nectar call and the AA write entirely, since the command's purpose is backfilling missing values. A `-force` flag bypasses the check for deliberate recompute.
* `pfp/cmd/main.go`: standalone binary boilerplate (same pattern as cid/cmd/main.go).
* `main.go`: wires `starling file pfp` into the `file` group switch alongside `cid` and `c2pa`.
* `docs/cli.md`: adds `pfp` entry under the `file` group.
* `pfp/pfp_test.go`: unit tests using an in-memory `fakeAA` stub and an `httptest.Server` for Nectar. They cover:
  * no existing value (computes and writes)
  * existing value short-circuits (no Nectar call, no AA write)
  * `-force` recomputes and overwrites
  * non-`ErrNotFound` AA errors propagate
  * missing file
  * unsupported media type
  * AA write errors propagate
* `pfp/pfp_integration_test.go`: env-gated live test (`NECTAR_URL`/`NECTAR_TOKEN`) exercising the full code path against a real Nectar `/pfps` endpoint. Skips by default so `go test ./....` stays offline.

Closes #88 